### PR TITLE
Order of parameters into the $.extend function

### DIFF
--- a/jquery.numberfield.js
+++ b/jquery.numberfield.js
@@ -23,7 +23,7 @@
             options = {};
         }
         var defaultOptions = {ints: 2, floats: 6, separator: "."};
-        options = $.extend( options, defaultOptions );
+        options = $.extend( defaultOptions, options );
         var intNumAllow = options.ints;
         var floatNumAllow = options.floats;
         var separator = options.separator;


### PR DESCRIPTION
I am using this plugin and I found a trouble to set my options. It didn't work to me. I think the second parameter overwrites the first parameter in the extend function. When I changed the order of these parameters it worked.
